### PR TITLE
Handle null values in snapshot

### DIFF
--- a/rxvms_learning/lib/pages/cat_facts_page.dart
+++ b/rxvms_learning/lib/pages/cat_facts_page.dart
@@ -43,19 +43,22 @@ class _CatFactsPageState extends State<CatFactsPage> {
         stream: sl.get<CatFactsManager>().getCatFactsCommand.results,
         builder: (context, snapshot) {
           final result = snapshot.data;
-          if (result.isExecuting) {
-            return Center(child: CircularProgressIndicator());
-          } else if (result.hasData) {
-            return ListView.builder(
-              itemCount: result.data.length,
-              itemBuilder: (context, index) {
-                final catFact = result.data[index];
-                return CatFactsTile(catFact: catFact);
-              },
-            );
-          } else {
-            return Center(child: Text('There was an error'));
+          if(result != null) {
+            if (result.isExecuting) {
+                return Center(child: CircularProgressIndicator());
+            } else if (result.hasData) {
+                return ListView.builder(
+                itemCount: result.data.length,
+                itemBuilder: (context, index) {
+                    final catFact = result.data[index];
+                    return CatFactsTile(catFact: catFact);
+                },
+                );
+            } else {
+                return Center(child: Text('There was an error'));
+            }
           }
+          return Center(child: Text('Nothing to show'));
         },
       ),
       floatingActionButton: FloatingActionButton(


### PR DESCRIPTION
By default, the first result of a snapshot that doesn't have `initialData` is usually null. Even if you have already called the stream in `initState`. Hence, checking `result.isExecuting` immediately will throw an error. This commit goes ahead to check if `result` is null first, then goes ahead to check for the events